### PR TITLE
Ip 4332 separate data connect engine from worker kubernetes project

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -45,6 +45,14 @@ spec:
         {{ .Values.nodeSelector | toYaml | indent 8 | trim }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+      - name: dataconnect-engine
+        image: {{ .Values.dcEngineImage }}
+        imagePullPolicy: {{ .Values.dcEngineImagePullPolicy }}
+        command: ['sh', '-c', 'cp -RT tmp/actian/engine/di-standalone-engine-* /opt/Actian/engine"]
+        volumeMounts:
+        - name: dataconnect-engine-vol
+          mountPath: /opt/Actian/engine
       containers:
       - name: worker
         image: {{ .Values.image }}
@@ -74,8 +82,9 @@ spec:
           mountPath: /opt/Actian/volume
         - name: gcp-secrets
           readOnly: true
-          mountPath: /etc/secrets/gcp  
-
+          mountPath: /etc/secrets/gcp
+        - name: dataconnect-engine-vol
+          mountPath: /opt/Actian/engine
         {{- if .Values.extraVolumeMounts }}
         {{ .Values.extraVolumeMounts | toYaml | indent 8 | trim }}
         {{- end }}
@@ -119,6 +128,8 @@ spec:
       - name: license-vol
         configMap:
           name: {{ template "integration-manager-worker.fullname" . }}-license
+      - name: dataconnect-engine-vol
+        emptyDir: {}
       {{- if .Values.extraVolumes }}
       {{ .Values.extraVolumes | toYaml | indent 6 | trim }}
       {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -20,28 +20,6 @@ spec:
       release: {{ .Release.Name | quote }}
   template:
     metadata:
-      annotations:---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ template "integration-manager-worker.fullname" . }}
-  {{- if .Values.namespaced }}
-  namespace: {{ template "integration-manager-worker.namespace" . }}
-  {{- end }}
-  labels:
-    app: integration-manager-worker
-    chart: {{ template "integration-manager-worker.chart" . }}
-    release: {{ .Release.Name | quote }}
-    destinationId: {{ quote .Values.destinationId }}
-spec:
-  replicas: {{ .Values.replicaCount }}
-  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  selector:
-    matchLabels:
-      app: integration-manager-worker
-      release: {{ .Release.Name | quote }}
-  template:
-    metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
@@ -67,14 +45,6 @@ spec:
         {{ .Values.nodeSelector | toYaml | indent 8 | trim }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      initContainers:
-      - name: dataconnect-engine
-        image: {{ .Values.dcEngineImage }}
-        imagePullPolicy: {{ .Values.dcEngineImagePullPolicy }}
-        command: ['sh', '-c', 'cp -RT tmp/actian/engine/di-standalone-engine-* /opt/Actian/engine"]
-        volumeMounts:
-        - name: dataconnect-engine-vol
-          mountPath: /opt/Actian/engine
       containers:
       - name: worker
         image: {{ .Values.image }}
@@ -104,9 +74,8 @@ spec:
           mountPath: /opt/Actian/volume
         - name: gcp-secrets
           readOnly: true
-          mountPath: /etc/secrets/gcp
-        - name: dataconnect-engine-vol
-          mountPath: /opt/Actian/engine
+          mountPath: /etc/secrets/gcp  
+
         {{- if .Values.extraVolumeMounts }}
         {{ .Values.extraVolumeMounts | toYaml | indent 8 | trim }}
         {{- end }}
@@ -150,8 +119,6 @@ spec:
       - name: license-vol
         configMap:
           name: {{ template "integration-manager-worker.fullname" . }}-license
-      - name: dataconnect-engine-vol
-        emptyDir: {}
       {{- if .Values.extraVolumes }}
       {{ .Values.extraVolumes | toYaml | indent 6 | trim }}
       {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -49,20 +49,7 @@ spec:
       - name: dataconnect-engine
         image: {{ .Values.dcEngineImage }}
         imagePullPolicy: {{ .Values.dcEngineImagePullPolicy }}
-        env:
-        - name: IM_DRIVERS_DIR
-          value: /opt/Actian/engine/runtime/di9
-        command:
-        - /bin/sh
-        - -c
-        - |
-          echo "copying standalone-engine-* files from image to /opt/Actian/engine"
-          cp -RT tmp/actian/engine/di-standalone-engine-* /opt/Actian/engine
-          echo "Switch to unixODBC drivers"
-          rm -f ${IM_DRIVERS_DIR}/djodbc3.so ${IM_DRIVERS_DIR}/djodbc35.so
-          ln -s ${IM_DRIVERS_DIR}/djodbc3.unixodbc.so ${IM_DRIVERS_DIR}/djodbc3.so
-          ln -s ${IM_DRIVERS_DIR}/djodbc35.unixodbc.so ${IM_DRIVERS_DIR}/djodbc35.so
-          echo "done..."
+        command: ['sh', 'script.sh']
         volumeMounts:
         - name: dataconnect-engine-vol
           mountPath: /opt/Actian/engine

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -20,6 +20,28 @@ spec:
       release: {{ .Release.Name | quote }}
   template:
     metadata:
+      annotations:---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "integration-manager-worker.fullname" . }}
+  {{- if .Values.namespaced }}
+  namespace: {{ template "integration-manager-worker.namespace" . }}
+  {{- end }}
+  labels:
+    app: integration-manager-worker
+    chart: {{ template "integration-manager-worker.chart" . }}
+    release: {{ .Release.Name | quote }}
+    destinationId: {{ quote .Values.destinationId }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      app: integration-manager-worker
+      release: {{ .Release.Name | quote }}
+  template:
+    metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
@@ -45,6 +67,14 @@ spec:
         {{ .Values.nodeSelector | toYaml | indent 8 | trim }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+      - name: dataconnect-engine
+        image: {{ .Values.dcEngineImage }}
+        imagePullPolicy: {{ .Values.dcEngineImagePullPolicy }}
+        command: ["/bin/sh", "-c", "cp tmp/actian/engine/di-standalone-engine-* /opt/Actian/engine ; done"]
+        volumeMounts:
+        - name: dataconnect-engine-vol
+          mountPath: /opt/Actian/engine
       containers:
       - name: worker
         image: {{ .Values.image }}
@@ -74,8 +104,9 @@ spec:
           mountPath: /opt/Actian/volume
         - name: gcp-secrets
           readOnly: true
-          mountPath: /etc/secrets/gcp  
-
+          mountPath: /etc/secrets/gcp
+        - name: dataconnect-engine-vol
+          mountPath: /opt/Actian/engine
         {{- if .Values.extraVolumeMounts }}
         {{ .Values.extraVolumeMounts | toYaml | indent 8 | trim }}
         {{- end }}
@@ -119,6 +150,8 @@ spec:
       - name: license-vol
         configMap:
           name: {{ template "integration-manager-worker.fullname" . }}-license
+      - name: dataconnect-engine-vol
+        emptyDir: {}
       {{- if .Values.extraVolumes }}
       {{ .Values.extraVolumes | toYaml | indent 6 | trim }}
       {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -49,7 +49,20 @@ spec:
       - name: dataconnect-engine
         image: {{ .Values.dcEngineImage }}
         imagePullPolicy: {{ .Values.dcEngineImagePullPolicy }}
-        command: ['sh', '-c', 'cp -RT tmp/actian/engine/di-standalone-engine-* /opt/Actian/engine"]
+        env:
+        - name: IM_DRIVERS_DIR
+          value: /opt/Actian/engine/runtime/di9
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "copying standalone-engine-* files from image to /opt/Actian/engine"
+          cp -RT tmp/actian/engine/di-standalone-engine-* /opt/Actian/engine
+          echo "Switch to unixODBC drivers"
+          rm -f ${IM_DRIVERS_DIR}/djodbc3.so ${IM_DRIVERS_DIR}/djodbc35.so
+          ln -s ${IM_DRIVERS_DIR}/djodbc3.unixodbc.so ${IM_DRIVERS_DIR}/djodbc3.so
+          ln -s ${IM_DRIVERS_DIR}/djodbc35.unixodbc.so ${IM_DRIVERS_DIR}/djodbc35.so
+          echo "done..."
         volumeMounts:
         - name: dataconnect-engine-vol
           mountPath: /opt/Actian/engine

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
       - name: dataconnect-engine
         image: {{ .Values.dcEngineImage }}
         imagePullPolicy: {{ .Values.dcEngineImagePullPolicy }}
-        command: ["/bin/sh", "-c", "cp tmp/actian/engine/di-standalone-engine-* /opt/Actian/engine ; done"]
+        command: ['sh', '-c', 'cp -RT tmp/actian/engine/di-standalone-engine-* /opt/Actian/engine"]
         volumeMounts:
         - name: dataconnect-engine-vol
           mountPath: /opt/Actian/engine

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,8 @@
 imagePullSecrets: []
 image: actian/datacloud-worker:2.0.5.270
 imagePullPolicy: IfNotPresent
+dcEngineImage: actian/dataconnect-engine:latest
+dcEngineImagePullPolicy: IfNotPresent
 namespaced:
 revisionHistoryLimit: 10
 resultsQueue: JOB_RESULTS

--- a/values.yaml
+++ b/values.yaml
@@ -7,7 +7,7 @@
 imagePullSecrets: []
 image: actian/datacloud-worker:2.0.5.270
 imagePullPolicy: IfNotPresent
-dcEngineImage: actian/dataconnect-engine:latest
+dcEngineImage: actian/dataconnect-engine:11.6.0-98
 dcEngineImagePullPolicy: IfNotPresent
 namespaced:
 revisionHistoryLimit: 10


### PR DESCRIPTION
JIRA Ticket: https://alm.actian.com/jira/browse/IP-4332
Notes:
Adding emptyDir Volume type to hold the dataconnect Engine files.
Adding initContainer to run the script.sh file that pulls the dataconnect-engine image and then to copy the engine files to the /opt/Actian/engine location and also switch to unixODBC drivers. (script: https://alm.actian.com/bitbucket/projects/DF/repos/dataconnect-engine/browse/script.sh)
Adding emptyDir as the volumeMount for initcontainer and the container.
Adding dcEngineImage and dcEngineImagePullPolicy fields to values.yaml file.